### PR TITLE
feat(docs): Add JMRI SML overview

### DIFF
--- a/docs/jmri-sml/JMRI_SML_OVERVIEW.MD
+++ b/docs/jmri-sml/JMRI_SML_OVERVIEW.MD
@@ -1,0 +1,14 @@
+# JMRI Signal Mast Logic (SML) Overview
+
+JMRI's Signal Mast Logic (SML) is a powerful feature that allows for prototypical signaling on a model railroad. It uses a system of XML files to define signal systems, aspects, and appearances.
+
+## Key Features
+
+- **Prototypical Signaling:** SML allows for the creation of complex signaling logic that mimics real-world railroad operations.
+- **Customizable:** Users can create their own signal system definitions or use one of the many pre-built definitions.
+- **Aspect-based:** SML is based on the concept of signal aspects, which represent the different indications that a signal can display.
+
+## Resources
+
+- **JMRI Signal System Definitions:** [https://www.jmri.org/xml/signals/](https://www.jmri.org/xml/signals/)
+- **JMRI GitHub Repository (Signals):** [https://github.com/JMRI/JMRI/tree/master/xml/signals](https://github.com/JMRI/JMRI/tree/master/xml/signals)


### PR DESCRIPTION
Adds a new directory and overview document for JMRI Signal Mast Logic (SML), including links to the official documentation and GitHub repository.