### PR TITLE
refactor: Remove unused SimpleKalmanFilter library

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -26,7 +26,6 @@ lib_deps =
     https://github.com/chatelao/xDuinoRails_DccLightsAndFunctions.git
     https://github.com/Laserlicht/MaerklinMotorola.git
     https://github.com/chatelao/xDuinoRails_MotorControl.git
-    denyssene/SimpleKalmanFilter
     adafruit/Adafruit NeoPixel
     https://github.com/Makuna/DFMiniMp3.git
     https://github.com/khoih-prog/LittleFS_Mbed_RP2040.git


### PR DESCRIPTION
The SimpleKalmanFilter library was included as a dependency in platformio.ini but was not used in the firmware source code. This commit removes the unused dependency to reduce project bloat.