### PR TITLE
fix: Add missing sound library to fix build

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -24,6 +24,7 @@ framework = arduino
 lib_ignore = Servo
 lib_deps =
     https://github.com/chatelao/xDuinoRails_DccLightsAndFunctions.git
+    https://github.com/chatelao/xDuinoRails_SoundEngine.git
     https://github.com/Laserlicht/MaerklinMotorola.git
     https://github.com/chatelao/xDuinoRails_MotorControl.git
     denyssene/SimpleKalmanFilter

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -10,10 +10,10 @@
 #include "CVManagerAdapter.h"
 #include <xDuinoRails_DccLightsAndFunctions.h>
 #include <xDuinoRails_DccSounds.h>
-#include "sound/VSDReader.h"
-#include "sound/WAVStream.h"
-#include "sound/VSDConfigParser.h"
-#include "sound/SoftwareMixer.h"
+#include <VSDReader.h>
+#include <WAVStream.h>
+#include <VSDConfigParser.h>
+#include <SoftwareMixer.h>
 
 // --- Global Objects ---
 SoundController soundController;


### PR DESCRIPTION
The GitHub build was failing because the `sound/VSDReader.h` header file was not found. This was because the `xDuinoRails_SoundEngine` library, which contains the sound-related files, was not included as a dependency.

This commit fixes the build by:
- Adding `xDuinoRails_SoundEngine` to the `lib_deps` in `firmware/platformio.ini`.
- Updating the include paths in `firmware/src/main.cpp` to correctly reference the headers from the new library.