### PR TITLE
Add shunting and dwarf signal definitions for CH, IT, UK, US, AU, and FR

### DIFF
--- a/firmware/definitions/au.xml
+++ b/firmware/definitions/au.xml
@@ -41,4 +41,18 @@
       </aspect>
     </aspects>
   </signal>
+  <signal country="au" name="AU-NSW-Shunt-Color-Light" svg="AU-NSW-Shunt-Color-Light.svg">
+    <lightbulbs>
+      <lightbulb id="L1" x="0" y="200" color="yellow"/>
+      <lightbulb id="L2" x="0" y="0" color="red"/>
+    </lightbulbs>
+    <aspects>
+      <aspect name="Stop">
+        <light id="L2"/>
+      </aspect>
+      <aspect name="Proceed">
+        <light id="L1"/>
+      </aspect>
+    </aspects>
+  </signal>
 </signalDefinitions>

--- a/firmware/definitions/ch.xml
+++ b/firmware/definitions/ch.xml
@@ -117,4 +117,28 @@
       </aspect>
     </aspects>
   </signal>
+
+  <signal country="ch" name="CH-Zwergsignal" svg="CH-Zwergsignal.svg" outline="M -150,150 L 150,150 L 0,-150 Z" outlineColor="#000000">
+    <lightbulbs>
+      <!-- Triangle arrangement: L1 Top, L2 Bottom Left, L3 Bottom Right -->
+      <!-- Approximate dimensions in mm -->
+      <lightbulb id="L1" x="0" y="-100" color="white" d="m -40, 0 a 40,40 0 1,0 80,0 a 40,40 0 1,0 -80,0"/>
+      <lightbulb id="L2" x="-100" y="100" color="white" d="m -40, 0 a 40,40 0 1,0 80,0 a 40,40 0 1,0 -80,0"/>
+      <lightbulb id="L3" x="100" y="100" color="white" d="m -40, 0 a 40,40 0 1,0 80,0 a 40,40 0 1,0 -80,0"/>
+    </lightbulbs>
+    <aspects>
+      <aspect name="Halt"> <!-- Horizontal: L2 + L3 -->
+        <light id="L2"/>
+        <light id="L3"/>
+      </aspect>
+      <aspect name="Fahrt"> <!-- Diagonal /: L2 + L1 -->
+        <light id="L2"/>
+        <light id="L1"/>
+      </aspect>
+      <aspect name="Fahrt mit Vorsicht"> <!-- Diagonal \: L3 + L1 -->
+        <light id="L3"/>
+        <light id="L1"/>
+      </aspect>
+    </aspects>
+  </signal>
 </signalDefinitions>

--- a/firmware/definitions/fr.xml
+++ b/firmware/definitions/fr.xml
@@ -26,10 +26,14 @@
   <signal country="fr" name="FR-Carre-Violet-1" svg="FR-Carre-Violet-1.svg">
     <lightbulbs>
       <lightbulb id="L1" x="0" y="0" color="violet"/>
+      <lightbulb id="L2" x="0" y="-50" color="white"/>
     </lightbulbs>
     <aspects>
       <aspect name="Carré violet">
         <light id="L1"/>
+      </aspect>
+      <aspect name="Manoeuvre">
+        <light id="L2"/>
       </aspect>
     </aspects>
   </signal>

--- a/firmware/definitions/it.xml
+++ b/firmware/definitions/it.xml
@@ -19,4 +19,22 @@
       </aspect>
     </aspects>
   </signal>
+  <signal country="it" name="IT-Marmotta" svg="IT-Marmotta.svg">
+    <lightbulbs>
+      <lightbulb id="L1" x="-50" y="0" color="white"/> <!-- Left -->
+      <lightbulb id="L2" x="50" y="0" color="white"/>  <!-- Right -->
+      <lightbulb id="L3" x="0" y="50" color="white"/>  <!-- Top -->
+      <lightbulb id="L4" x="0" y="-50" color="white"/> <!-- Bottom -->
+    </lightbulbs>
+    <aspects>
+      <aspect name="Stop"> <!-- Via impedita -->
+        <light id="L1"/>
+        <light id="L2"/>
+      </aspect>
+      <aspect name="Proceed"> <!-- Via libera -->
+        <light id="L3"/>
+        <light id="L4"/>
+      </aspect>
+    </aspects>
+  </signal>
 </signalDefinitions>

--- a/firmware/definitions/uk.xml
+++ b/firmware/definitions/uk.xml
@@ -23,4 +23,22 @@
       </aspect>
     </aspects>
   </signal>
+  <signal country="uk" name="UK-Ground-Position-Light" svg="UK-Ground-Position-Light.svg">
+    <lightbulbs>
+      <lightbulb id="L1" x="-50" y="0" color="red"/>    <!-- Left Red -->
+      <lightbulb id="L2" x="50" y="0" color="red"/>     <!-- Right Red -->
+      <lightbulb id="L3" x="-50" y="0" color="white"/>  <!-- Left White (Pivot) -->
+      <lightbulb id="L4" x="50" y="100" color="white"/> <!-- Top Right White -->
+    </lightbulbs>
+    <aspects>
+      <aspect name="Danger">
+        <light id="L1"/>
+        <light id="L2"/>
+      </aspect>
+      <aspect name="Proceed">
+        <light id="L3"/>
+        <light id="L4"/>
+      </aspect>
+    </aspects>
+  </signal>
 </signalDefinitions>

--- a/firmware/definitions/us.xml
+++ b/firmware/definitions/us.xml
@@ -18,4 +18,22 @@
       </aspect>
     </aspects>
   </signal>
+  <signal country="us" name="US-Dwarf-Color-Light" svg="US-Dwarf-Color-Light.svg">
+    <lightbulbs>
+      <lightbulb id="L1" x="0" y="300" color="green"/>
+      <lightbulb id="L2" x="0" y="0" color="yellow"/>
+      <lightbulb id="L3" x="0" y="-300" color="red"/>
+    </lightbulbs>
+    <aspects>
+      <aspect name="Stop">
+        <light id="L3"/>
+      </aspect>
+      <aspect name="Clear">
+        <light id="L1"/>
+      </aspect>
+      <aspect name="Approach">
+        <light id="L2"/>
+      </aspect>
+    </aspects>
+  </signal>
 </signalDefinitions>


### PR DESCRIPTION
- Added `CH-Zwergsignal` (Swiss dwarf signal) with Halt, Fahrt, and Fahrt mit Vorsicht aspects.
- Added `IT-Marmotta` (Italian shunting signal) with Stop and Proceed aspects.
- Added `UK-Ground-Position-Light` (UK shunting signal) with Danger and Proceed aspects.
- Added `US-Dwarf-Color-Light` (US dwarf signal) with Stop, Approach, and Clear aspects.
- Added `AU-NSW-Shunt-Color-Light` (Australian shunting signal) with Stop and Proceed aspects.
- Updated `FR-Carre-Violet-1` (French shunting signal) to include the White light and "Manoeuvre" aspect.
- Verified XML validity against `signals.xsd`.