### PR TITLE
Add Swiss Combined Signal Discrete concept and test board documentation

### DIFF
--- a/docs/TEST_BOARD_CONCEPT.md
+++ b/docs/TEST_BOARD_CONCEPT.md
@@ -1,0 +1,64 @@
+# Test Board Concept
+
+This document outlines the concept for a test board featuring a 9x9 NeoPixel matrix and a discrete LED implementation of a complex Swiss railway signal.
+
+## Overview
+
+The test board is designed to verify the functionality of the signal decoder firmware, specifically focusing on:
+1.  **Matrix Display Control:** Using a 9x9 NeoPixel matrix (81 LEDs).
+2.  **Discrete Signal Control:** Driving a complex Swiss signal using individual GPIO pins for each light source, rather than NeoPixels.
+
+## Hardware Components
+
+### 1. 9x9 NeoPixel Matrix
+*   **Type:** WS2812B (or compatible) addressable LEDs.
+*   **Configuration:** 9 rows x 9 columns = 81 pixels.
+*   **Connection:** Single Data Pin (e.g., GPIO 0).
+*   **Power:** 5V External power supply recommended due to high current draw (approx. 4.8A max for 81 pixels white).
+
+### 2. Discrete LED Swiss Signal
+The signal selected for this concept is the **Swiss System L** configuration, specifically a **Main Signal (Hauptsignal)** combined with a **Distant Signal (Vorsignal)**. This configuration offers the highest count of discrete optical elements (lights) typically found in this system.
+
+#### Signal Layout
+The signal consists of two distinct heads (or a combined shield representation) with the following LED mapping:
+
+**Main Signal (Hauptsignal - Type 4L):**
+*   **LED 1 (Green):** Top - Proceed / Speed 60 (upper)
+*   **LED 2 (Red):** Upper Middle - Stop
+*   **LED 3 (Yellow):** Lower Middle - Caution / Short Proceed
+*   **LED 4 (Green):** Bottom - Speed 60 (lower) / Speed 40 (lower?)
+
+**Distant Signal (Vorsignal - Standard):**
+*   **LED 5 (Yellow):** Top Left - Warning / Expect Stop
+*   **LED 6 (Yellow):** Top Right - Warning / Expect Stop
+*   **LED 7 (Green):** Bottom Left - Expect Proceed
+*   **LED 8 (Green):** Bottom Right - Expect Proceed
+
+*Note: In a physical "Combined Signal" (Kombisignal), some optics might be shared or arranged on a single square plate, but for this discrete LED test board, we treat them as 8 individual controlled light sources to maximize testing capability.*
+
+#### Pin Mapping (Example for RP2040)
+| Component | Function | Pin (GPIO) |
+| :--- | :--- | :--- |
+| **Matrix** | Data Input | 0 |
+| **Signal** | Main Green (Top) | 1 |
+| **Signal** | Main Red | 2 |
+| **Signal** | Main Yellow | 3 |
+| **Signal** | Main Green (Bot) | 4 |
+| **Signal** | Dist Yellow (TL) | 5 |
+| **Signal** | Dist Yellow (TR) | 6 |
+| **Signal** | Dist Green (BL) | 7 |
+| **Signal** | Dist Green (BR) | 26 |
+| **Ground** | GND | GND |
+
+*(Pins can be adjusted based on available GPIOs)*
+
+## Signal Logic
+The firmware will implement a new class `SwissCombinedSignalDiscrete` which controls these 8 discrete LEDs to form valid Swiss signal aspects.
+
+### Supported Aspects (Subset)
+*   **Halt (Stop):** Main Red.
+*   **Freie Fahrt (Proceed):** Main Green (Top).
+*   **Warnung (Caution):** Main Green (Top) + Distant Yellows.
+*   **Kurze Fahrt (Short Proceed):** Main Yellow + Main Green (depending on exact definition).
+*   **Speed 40:** Main Green (Top) + Main Yellow.
+*   **Speed 60:** Main Green (Top) + Main Green (Bot).

--- a/firmware/lib/xDuinoRails_DccLightsAndFunctions/examples/SwissCombinedSignalDiscrete/SwissCombinedSignalDiscrete.cpp
+++ b/firmware/lib/xDuinoRails_DccLightsAndFunctions/examples/SwissCombinedSignalDiscrete/SwissCombinedSignalDiscrete.cpp
@@ -1,0 +1,79 @@
+#include <Arduino.h>
+#include <Adafruit_NeoPixel.h>
+#include "LightSources/SwissCombinedSignalDiscrete.h"
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// NeoPixel Matrix (9x9 = 81 pixels)
+#define MATRIX_PIN      0
+#define MATRIX_WIDTH    9
+#define MATRIX_HEIGHT   9
+#define NUM_PIXELS      (MATRIX_WIDTH * MATRIX_HEIGHT)
+
+// Discrete Signal Pins
+// Mapping: G_Top, Red, Yellow, G_Bot, Dist_Y_TL, Dist_Y_TR, Dist_G_BL, Dist_G_BR
+const uint8_t SIGNAL_PINS[] = { 1, 2, 3, 4, 5, 6, 7, 26 };
+
+// ---------------------------------------------------------------------------
+// Objects
+// ---------------------------------------------------------------------------
+
+Adafruit_NeoPixel matrix(NUM_PIXELS, MATRIX_PIN, NEO_GRB + NEO_KHZ800);
+xDuinoRails::SwissCombinedSignalDiscrete swissSignal(SIGNAL_PINS);
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+void setup() {
+    // Initialize Matrix
+    matrix.begin();
+    matrix.setBrightness(50);
+    matrix.clear();
+
+    // simple pattern on matrix to show it works
+    for(int i=0; i<NUM_PIXELS; i++) {
+        if ((i / 9) == (i % 9)) { // Diagonal
+            matrix.setPixelColor(i, matrix.Color(0, 0, 255));
+        }
+    }
+    matrix.show();
+
+    // Initialize Signal
+    swissSignal.begin();
+    swissSignal.setLevel(255); // Full brightness
+}
+
+// ---------------------------------------------------------------------------
+// Loop
+// ---------------------------------------------------------------------------
+
+void loop() {
+    // Cycle through aspects every 2 seconds
+
+    // 1. Stop
+    swissSignal.setAspect(xDuinoRails::SCS_ASPECT_STOP);
+    delay(2000);
+
+    // 2. Clear
+    swissSignal.setAspect(xDuinoRails::SCS_ASPECT_CLEAR);
+    delay(2000);
+
+    // 3. Expect 40
+    swissSignal.setAspect(xDuinoRails::SCS_ASPECT_EXPECT_40);
+    delay(2000);
+
+    // 4. Speed 40
+    swissSignal.setAspect(xDuinoRails::SCS_ASPECT_SPEED_40);
+    delay(2000);
+
+    // 5. Speed 60
+    swissSignal.setAspect(xDuinoRails::SCS_ASPECT_SPEED_60);
+    delay(2000);
+
+    // 6. Warning
+    swissSignal.setAspect(xDuinoRails::SCS_ASPECT_WARN);
+    delay(2000);
+}

--- a/firmware/lib/xDuinoRails_DccLightsAndFunctions/src/LightSources/SwissCombinedSignalDiscrete.cpp
+++ b/firmware/lib/xDuinoRails_DccLightsAndFunctions/src/LightSources/SwissCombinedSignalDiscrete.cpp
@@ -1,0 +1,90 @@
+#include "SwissCombinedSignalDiscrete.h"
+
+namespace xDuinoRails {
+
+SwissCombinedSignalDiscrete::SwissCombinedSignalDiscrete(const uint8_t* pins) : _aspect(SCS_ASPECT_STOP), _level(255) {
+    for (int i = 0; i < 8; i++) {
+        _pins[i] = pins[i];
+    }
+}
+
+void SwissCombinedSignalDiscrete::begin() {
+    for (int i = 0; i < 8; i++) {
+        pinMode(_pins[i], OUTPUT);
+        digitalWrite(_pins[i], LOW);
+    }
+}
+
+void SwissCombinedSignalDiscrete::on() {
+    setAspect(_aspect);
+}
+
+void SwissCombinedSignalDiscrete::off() {
+    for (int i = 0; i < 8; i++) {
+        digitalWrite(_pins[i], LOW);
+    }
+}
+
+void SwissCombinedSignalDiscrete::setLevel(uint8_t level) {
+    _level = level;
+    on(); // Update outputs
+}
+
+void SwissCombinedSignalDiscrete::update(uint32_t delta_ms) {
+    // No blinking implemented in this basic concept
+    (void)delta_ms;
+}
+
+void SwissCombinedSignalDiscrete::writePin(uint8_t pinIndex, bool state) {
+    if (state) {
+        analogWrite(_pins[pinIndex], _level);
+    } else {
+        digitalWrite(_pins[pinIndex], LOW);
+    }
+}
+
+void SwissCombinedSignalDiscrete::setAspect(SwissCombinedSignalAspect aspect) {
+    _aspect = aspect;
+
+    // Turn all off first (internal state)
+    bool states[8] = {0}; // G_T, R, Y, G_B, DY_TL, DY_TR, DG_BL, DG_BR
+
+    switch (_aspect) {
+        case SCS_ASPECT_STOP:
+            states[1] = true; // Red
+            break;
+        case SCS_ASPECT_CLEAR:
+            states[0] = true; // Green Top
+            // Distant implicitly clear (all off)
+            break;
+        case SCS_ASPECT_WARN:
+            states[0] = true; // Green Top
+            states[4] = true; // Distant Yellow TL
+            states[5] = true; // Distant Yellow TR
+            break;
+        case SCS_ASPECT_EXPECT_40:
+            states[0] = true; // Green Top
+            states[4] = true; // Distant Yellow TL
+            states[7] = true; // Distant Green BR
+            break;
+        case SCS_ASPECT_SPEED_40:
+            states[0] = true; // Green Top
+            states[2] = true; // Main Yellow
+            break;
+        case SCS_ASPECT_SPEED_60:
+            states[0] = true; // Green Top
+            states[3] = true; // Main Green Bottom
+            break;
+        case SCS_ASPECT_SHORT_PROCEED:
+             // Fallback representation
+             states[2] = true; // Main Yellow
+             states[4] = true; // Distant Yellow TL
+             break;
+    }
+
+    for (int i = 0; i < 8; i++) {
+        writePin(i, states[i]);
+    }
+}
+
+} // namespace xDuinoRails

--- a/firmware/lib/xDuinoRails_DccLightsAndFunctions/src/LightSources/SwissCombinedSignalDiscrete.h
+++ b/firmware/lib/xDuinoRails_DccLightsAndFunctions/src/LightSources/SwissCombinedSignalDiscrete.h
@@ -1,0 +1,62 @@
+#ifndef SWISSCOMBINEDSIGNALDISCRETE_H
+#define SWISSCOMBINEDSIGNALDISCRETE_H
+
+#include "LightSource.h"
+#include <Arduino.h>
+#include <vector>
+
+namespace xDuinoRails {
+
+/**
+ * @enum SwissCombinedSignalAspect
+ * @brief Aspects for the Swiss Combined Signal (Discrete LED version).
+ */
+enum SwissCombinedSignalAspect {
+    SCS_ASPECT_STOP,                ///< Main: Red
+    SCS_ASPECT_CLEAR,               ///< Main: Green, Distant: Off (Implied Clear)
+    SCS_ASPECT_WARN,                ///< Main: Green, Distant: Warning (YY)
+    SCS_ASPECT_EXPECT_40,           ///< Main: Green, Distant: Expect 40 (YG)
+    SCS_ASPECT_SPEED_40,            ///< Main: Green + Yellow (40)
+    SCS_ASPECT_SPEED_60,            ///< Main: Green + Green (60)
+    SCS_ASPECT_SHORT_PROCEED        ///< Main: Yellow + Yellow? or specific short proceed pattern
+};
+
+class SwissCombinedSignalDiscrete : public LightSource {
+public:
+    /**
+     * @brief Construct a new Swiss Combined Signal Discrete object
+     *
+     * @param pins An array of 8 pins:
+     *             0: Main Green (Top)
+     *             1: Main Red
+     *             2: Main Yellow
+     *             3: Main Green (Bottom)
+     *             4: Distant Yellow (Top Left)
+     *             5: Distant Yellow (Top Right)
+     *             6: Distant Green (Bottom Left)
+     *             7: Distant Green (Bottom Right)
+     */
+    SwissCombinedSignalDiscrete(const uint8_t* pins);
+
+    void begin() override;
+    void on() override;
+    void off() override;
+    void setLevel(uint8_t level) override;
+    void update(uint32_t delta_ms) override;
+
+    void setAspect(SwissCombinedSignalAspect aspect);
+
+private:
+    uint8_t _pins[8];
+    SwissCombinedSignalAspect _aspect;
+    uint8_t _level; // Brightness is simulated via PWM if supported, or just ON/OFF
+
+    // Helper to write to pins considering "level" (if we use PWM)
+    // For discrete concept, we might just use digital writes for now,
+    // or analogWrite if pins support it.
+    void writePin(uint8_t pinIndex, bool state);
+};
+
+}
+
+#endif // SWISSCOMBINEDSIGNALDISCRETE_H

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -70,3 +70,16 @@ build_flags =
 lib_deps =
   adafruit/Adafruit NeoPixel
   ./lib/xDuinoRails_DccLightsAndFunctions
+
+[env:test_board_concept]
+platform = https://github.com/Seeed-Studio/platform-seeedboards.git
+board = seeed-xiao-rp2040
+framework = arduino
+build_flags =
+  -I lib/xDuinoRails_DccLightsAndFunctions/src
+lib_deps =
+  adafruit/Adafruit NeoPixel
+  ./lib/xDuinoRails_DccLightsAndFunctions
+build_src_filter =
+  -<*>
+  +<../lib/xDuinoRails_DccLightsAndFunctions/examples/SwissCombinedSignalDiscrete/SwissCombinedSignalDiscrete.cpp>


### PR DESCRIPTION
- Added `docs/TEST_BOARD_CONCEPT.md` outlining the concept for a test board with a 9x9 NeoPixel matrix and a discrete LED Swiss Combined Signal.
- Implemented `SwissCombinedSignalDiscrete` class in `firmware/lib/xDuinoRails_DccLightsAndFunctions/src/LightSources/`.
- Added example code `SwissCombinedSignalDiscrete.cpp` in `firmware/lib/xDuinoRails_DccLightsAndFunctions/examples/`.
- Added `env:test_board_concept` to `firmware/platformio.ini` to build the example.