### PR TITLE
Update webtool title to 'xDuinoRails - Signal Web Viewer'

### DIFF
--- a/webtool/index.html
+++ b/webtool/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Signal Viewer</title>
+    <title>xDuinoRails - Signal Web Viewer</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <style>
         body {
@@ -70,7 +70,7 @@
     </style>
 </head>
 <body>
-    <h1>Signal Viewer</h1>
+    <h1>xDuinoRails - Signal Web Viewer</h1>
 
     <div class="controls">
         <div class="control-group">


### PR DESCRIPTION
Updated the `<title>` tag and the `<h1>` header in `webtool/index.html` to be more descriptive and consistent with the project branding. Verified the change with a Playwright script and visual inspection of a screenshot.