### PR TITLE
Fix Swiss System N signal definitions

### DIFF
--- a/firmware/definitions/ch.xml
+++ b/firmware/definitions/ch.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <signalDefinitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="signals.xsd">
   <!-- System N Signals -->
-  <signal country="ch" name="CH-N-Hauptsignal-1" svg="CH-N-Hauptsignal-1.svg" outline="M -350,750 L 350,750 L 350,-750 L -350,-750 Z" outlineColor="#000000">
+  <signal country="ch" name="CH-N-Hauptsignal-1" svg="CH-N-Hauptsignal-1.svg" outline="M -250,350 L 250,350 L 350,250 L 350,-250 L 250,-350 L -250,-350 L -350,-250 L -350,250 Z" outlineColor="#6c6c6c">
     <lightbulbs>
-      <lightbulb id="L1" x="0" y="500" color="green" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
-      <lightbulb id="L2" x="-250" y="0" color="yellow" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
-      <lightbulb id="L3" x="250" y="0" color="red" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
-      <lightbulb id="L4" x="0" y="-500" color="white" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
+      <!-- Triangular layout: L3 (Red) Top, L2 (Orange) Left, L1 (Green) Right -->
+      <lightbulb id="L1" x="200" y="-200" color="green" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
+      <lightbulb id="L2" x="-200" y="-200" color="orange" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
+      <lightbulb id="L3" x="0" y="200" color="red" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
     </lightbulbs>
     <aspects>
       <aspect name="Halt">
@@ -18,12 +18,16 @@
       <aspect name="Warnung">
         <light id="L2"/>
       </aspect>
+      <aspect name="Hilfssignal">
+        <light id="L3" blink="true"/>
+      </aspect>
     </aspects>
   </signal>
-  <signal country="ch" name="CH-N-Vorsignal-1" svg="CH-N-Vorsignal-1.svg" outline="M -350,750 L 350,750 L 350,-750 L -350,-750 Z" outlineColor="#000000">
+  <signal country="ch" name="CH-N-Vorsignal-1" svg="CH-N-Vorsignal-1.svg" outline="M -250,350 L 250,350 L 350,250 L 350,-250 L 250,-350 L -250,-350 L -350,-250 L -350,250 Z" outlineColor="#6c6c6c">
     <lightbulbs>
-      <lightbulb id="L1" x="0" y="500" color="green" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
-      <lightbulb id="L2" x="-250" y="0" color="yellow" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
+      <!-- Triangular layout without Top Red -->
+      <lightbulb id="L1" x="200" y="-200" color="green" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
+      <lightbulb id="L2" x="-200" y="-200" color="orange" d="m -100, 0 a 100,100 0 1,0 200,0 a 100,100 0 1,0 -200,0"/>
     </lightbulbs>
     <aspects>
       <aspect name="Freie Fahrt">

--- a/firmware/definitions/signals.xsd
+++ b/firmware/definitions/signals.xsd
@@ -30,6 +30,7 @@
                           <xs:element name="light" maxOccurs="unbounded">
                             <xs:complexType>
                               <xs:attribute name="id" type="xs:string" use="required"/>
+                              <xs:attribute name="blink" type="xs:boolean" use="optional"/>
                             </xs:complexType>
                           </xs:element>
                         </xs:sequence>


### PR DESCRIPTION
- Updated `CH-N-Hauptsignal-1` and `CH-N-Vorsignal-1` in `firmware/definitions/ch.xml` to match the correct prototypical layout (Triangular).
- Corrected light positions: Red (Top), Orange (Left), Green (Right).
- Changed signal outline to a chamfered square and set color to grey `#6c6c6c`.
- Updated `yellow` lights to `orange`.
- Added `Hilfssignal` aspect to `CH-N-Hauptsignal-1` with blinking Red light.
- Updated `firmware/definitions/signals.xsd` to support optional `blink` attribute on `light` elements.
- Verified changes via XML validation and coordinate verification.