### PR TITLE
Add responsive navigation menu to webtool

### DIFF
--- a/webtool/editor.html
+++ b/webtool/editor.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>xDuinoRails - Signal Editor</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="stylesheet" href="menu.css">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            padding: 20px;
+            max-width: 1400px; /* Match index.html */
+            margin: 0 auto;
+            background-color: #ffe6e6; /* Match others */
+        }
+        h1 { text-align: center; color: #333; }
+        .content {
+            background: #eeeeee;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            min-height: 400px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+    </style>
+</head>
+<body>
+    <script src="menu.js"></script>
+
+    <h1>xDuinoRails - Signal Editor</h1>
+
+    <div class="content">
+        <p style="font-style: italic; color: #666;">Editor coming soon...</p>
+    </div>
+</body>
+</html>

--- a/webtool/gallery.html
+++ b/webtool/gallery.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>xDuinoRails - Signal Gallery</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="stylesheet" href="menu.css">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -111,11 +112,8 @@
     </style>
 </head>
 <body>
+    <script src="menu.js"></script>
     <h1>xDuinoRails - Signal Gallery</h1>
-
-    <div class="nav-bar">
-        <a href="index.html" class="button-link">Back to Viewer</a>
-    </div>
 
     <div id="gallery-container">
         <div class="loading">Loading signals...</div>

--- a/webtool/index.html
+++ b/webtool/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>xDuinoRails - Signal Web Viewer</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="stylesheet" href="menu.css">
     <style>
         * {
             box-sizing: border-box;
@@ -215,6 +216,7 @@
     </style>
 </head>
 <body>
+    <script src="menu.js"></script>
     <h1>xDuinoRails - Signal Web Viewer</h1>
 
     <div class="main-content">

--- a/webtool/menu.css
+++ b/webtool/menu.css
@@ -1,0 +1,53 @@
+/* Menu Styles */
+.topnav {
+    background-color: #333;
+    overflow: hidden;
+    margin-bottom: 20px;
+    border-radius: 4px;
+}
+
+.topnav a {
+    float: left;
+    display: block;
+    color: #f2f2f2;
+    text-align: center;
+    padding: 14px 16px;
+    text-decoration: none;
+    font-size: 17px;
+}
+
+.topnav a:hover {
+    background-color: #ddd;
+    color: black;
+}
+
+.topnav a.active {
+    background-color: #04AA6D;
+    color: white;
+}
+
+.topnav .icon {
+    display: none;
+}
+
+@media screen and (max-width: 600px) {
+    .topnav a:not(:first-child) {display: none;}
+    .topnav a.icon {
+        float: right;
+        display: block;
+    }
+}
+
+@media screen and (max-width: 600px) {
+    .topnav.responsive {position: relative;}
+    .topnav.responsive .icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
+    .topnav.responsive a {
+        float: none;
+        display: block;
+        text-align: left;
+    }
+}

--- a/webtool/menu.js
+++ b/webtool/menu.js
@@ -1,0 +1,42 @@
+document.addEventListener("DOMContentLoaded", function() {
+    // Inject Menu HTML
+    const navHtml = `
+        <div class="topnav" id="myTopnav">
+            <a href="index.html" id="link-viewer">Viewer</a>
+            <a href="gallery.html" id="link-gallery">Gallerie</a>
+            <a href="editor.html" id="link-editor">Editor</a>
+            <a href="javascript:void(0);" class="icon" onclick="toggleMenu()">
+                <svg viewBox="0 0 100 80" width="20" height="20" fill="white">
+                    <rect width="100" height="20"></rect>
+                    <rect y="30" width="100" height="20"></rect>
+                    <rect y="60" width="100" height="20"></rect>
+                </svg>
+            </a>
+        </div>
+    `;
+
+    // Prepend to body
+    document.body.insertAdjacentHTML('afterbegin', navHtml);
+
+    // Set Active Link
+    const path = window.location.pathname;
+    const page = path.split("/").pop();
+
+    if (page === "gallery.html") {
+        document.getElementById("link-gallery").classList.add("active");
+    } else if (page === "editor.html") {
+        document.getElementById("link-editor").classList.add("active");
+    } else {
+        // Default to index.html or empty (root)
+        document.getElementById("link-viewer").classList.add("active");
+    }
+});
+
+function toggleMenu() {
+    var x = document.getElementById("myTopnav");
+    if (x.className === "topnav") {
+        x.className += " responsive";
+    } else {
+        x.className = "topnav";
+    }
+}


### PR DESCRIPTION
- Introduced shared `menu.js` and `menu.css` for consistent navigation.
- Created `editor.html` as a placeholder for the new Editor page.
- Updated `index.html` (Viewer) and `gallery.html` to use the new menu system.
- Replaced the old "Back to Viewer" link in the gallery with the global menu.
- Implemented responsive mobile menu with hamburger toggle.